### PR TITLE
Compatibility with the first char of fileExt is a dot

### DIFF
--- a/src/FastDFS/Client/UPLOAD_APPEND_FILE.cs
+++ b/src/FastDFS/Client/UPLOAD_APPEND_FILE.cs
@@ -20,6 +20,10 @@ namespace FastDFS.Client
 
             StorageNode storageNode = (StorageNode)paramList[0];
             string fileExt = (string)paramList[1];
+            if (fileExt[0] == '.')
+            {
+                fileExt = fileExt.Substring(1);
+            }
             byte[] contentByte = (byte[])paramList[2];
 
             int contentByteLength = contentByte.Length;

--- a/src/FastDFS/Client/UPLOAD_FILE.cs
+++ b/src/FastDFS/Client/UPLOAD_FILE.cs
@@ -20,6 +20,10 @@ namespace FastDFS.Client
 
             StorageNode storageNode = (StorageNode) paramList[0];
             string fileExt = (string) paramList[1];
+            if (fileExt[0] == '.')
+            {
+                fileExt = fileExt.Substring(1);
+            }
             byte[] contentByte = (byte[]) paramList[2];
 
             int contentByteLength = contentByte.Length;


### PR DESCRIPTION
The System.IO.Path.GetExtension method return extesion with dot,  like this '.jpg', '.png'.